### PR TITLE
bugfix: Fix issue with returning false on SpeechRecognizer.isRecognitionAvailable() method in Android 11

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,4 +25,10 @@
         </activity>
     </application>
 
+    <queries>
+        <intent>
+            <action android:name="android.speech.RecognitionService" />
+        </intent>
+    </queries>
+
 </manifest>


### PR DESCRIPTION
There's issue with always getting false when trying to launch recognition on Android 11. This fix resolves that issue.